### PR TITLE
Reduce chunk size from the defaults.

### DIFF
--- a/bin/cvmfs_sync
+++ b/bin/cvmfs_sync
@@ -92,7 +92,7 @@ def kickoff_graft(fp, input_url, output_filename):
         try:
             os.dup2(readfp, 0)
             os.close(writefp)
-            args = ['cvmfs_swissknife', 'graft', '-i', '-', '-o', output_filename, '-Z', 'none']
+            args = ['cvmfs_swissknife', 'graft', '-i', '-', '-o', output_filename, '-Z', 'none', '-c', '24']
             os.execvp("cvmfs_swissknife", args)
         finally:
             print "Failed to exec cvmfs_swissknife for processing", input_url

--- a/bin/stash_async
+++ b/bin/stash_async
@@ -70,7 +70,7 @@ def kickoff_graft(fp, input_url, output_filename, deadline):
         try:
             os.dup2(readfp, 0)
             os.close(writefp)
-            args = ['cvmfs_swissknife', 'graft', '-i', '-', '-o', output_filename, '-Z', 'none']
+            args = ['cvmfs_swissknife', 'graft', '-i', '-', '-o', output_filename, '-Z', 'none', '-c', '24']
             os.execvp("cvmfs_swissknife", args)
         finally:
             print "Failed to exec cvmfs_swissknife for processing", input_url


### PR DESCRIPTION
CVMFS has alternate logic that is more aggressive in cache purging for
chunks over 24MB.  Hence, let's bump it down slightly in our scripts.