### PR TITLE
Update to allow for Robot Certs

### DIFF
--- a/bin/ligo-auth-gen
+++ b/bin/ligo-auth-gen
@@ -21,7 +21,7 @@ def main():
     opts, args = parse_opts()
     ldap_obj = ldap.initialize(opts.url)
     query = "(&(isMemberOf=%s)(gridX509subject=*))" % opts.group
-    results = ldap_obj.search_s(opts.base, ldap.SCOPE_ONELEVEL, query, ["gridX509subject"])
+    results = ldap_obj.search_s(opts.base, ldap.SCOPE_SUBTREE, query, ["gridX509subject"])
     all_dns = []
     for result in results:
         user_dns = result[1].get('gridX509subject', [])


### PR DESCRIPTION
With this change we can now access Robot Certs and still do users too:

```
 python ligo-auth-gen -b "ou=robot,dc=ligo,dc=org" -g "Communities:robot:OSGRobotCert"
/DC=org/DC=incommon/C=US/ST=Michigan/L=Ann Arbor/O=University Corporation For Advanced Internet Development/CN=osg-sunnyvale-stashcache.nrp.internet2.edu
```