### PR TITLE
Updated config files to match production

### DIFF
--- a/config/dune.osgstorage.org.config
+++ b/config/dune.osgstorage.org.config
@@ -2,6 +2,7 @@
 [CVMFS]
 repo = dune.osgstorage.org
 
-[Sync mu2e]
-source = root://fndca1.fnal.gov:1095/pnfs/fnal.gov/usr/dune/persistent/stash/
+[Sync dune]
+#source = root://fndca1.fnal.gov:1095/pnfs/fnal.gov/usr/dune/persistent/stash/
+source = root://stashcache.fnal.gov//pnfs/fnal.gov/usr/dune/persistent/stash/
 destination = /cvmfs/dune.osgstorage.org/pnfs/fnal.gov/usr/dune/persistent/stash/

--- a/config/minerva.osgstorage.org.config
+++ b/config/minerva.osgstorage.org.config
@@ -2,6 +2,7 @@
 [CVMFS]
 repo = minerva.osgstorage.org
 
-[Sync mu2e]
-source = root://fndca1.fnal.gov:1095/pnfs/fnal.gov/usr/minerva/persistent/stash/
+[Sync minerva]
+#source = root://fndca1.fnal.gov:1095/pnfs/fnal.gov/usr/minerva/persistent/stash/
+source = root://stashcache.fnal.gov//pnfs/fnal.gov/usr/minerva/persistent/stash/
 destination = /cvmfs/minerva.osgstorage.org/pnfs/fnal.gov/usr/minerva/persistent/stash/

--- a/config/mu2e.osgstorage.org.config
+++ b/config/mu2e.osgstorage.org.config
@@ -4,4 +4,5 @@ repo = mu2e.osgstorage.org
 
 [Sync mu2e]
 source = root://fndca1.fnal.gov:1095/pnfs/fnal.gov/usr/mu2e/persistent/stash/
+source = root://stashcache.fnal.gov//pnfs/fnal.gov/usr/mu2e/persistent/stash/
 destination = /cvmfs/mu2e.osgstorage.org/pnfs/fnal.gov/usr/mu2e/persistent/stash/

--- a/config/mu2e.osgstorage.org.config
+++ b/config/mu2e.osgstorage.org.config
@@ -3,6 +3,6 @@
 repo = mu2e.osgstorage.org
 
 [Sync mu2e]
-source = root://fndca1.fnal.gov:1095/pnfs/fnal.gov/usr/mu2e/persistent/stash/
+#source = root://fndca1.fnal.gov:1095/pnfs/fnal.gov/usr/mu2e/persistent/stash/
 source = root://stashcache.fnal.gov//pnfs/fnal.gov/usr/mu2e/persistent/stash/
 destination = /cvmfs/mu2e.osgstorage.org/pnfs/fnal.gov/usr/mu2e/persistent/stash/

--- a/config/uboone.osgstorage.org.config
+++ b/config/uboone.osgstorage.org.config
@@ -3,5 +3,6 @@
 repo = uboone.osgstorage.org
 
 [Sync uboone]
-source = root://fndca1.fnal.gov:1095/pnfs/fnal.gov/usr/uboone/persistent/stash/
+#source = root://fndca1.fnal.gov:1095/pnfs/fnal.gov/usr/uboone/persistent/stash/
+source = root://stashcache.fnal.gov//pnfs/fnal.gov/usr/uboone/persistent/stash/
 destination = /cvmfs/uboone.osgstorage.org/pnfs/fnal.gov/usr/uboone/persistent/stash/


### PR DESCRIPTION
All of the stashcache.fnal.gov URL’s need the double “//“.