### PR TITLE
For an xrootd hostname, try to choose a data server

### DIFF
--- a/bin/cvmfs_sync
+++ b/bin/cvmfs_sync
@@ -323,7 +323,30 @@ def process_files(base_url, gridftp_base_url, output_dir, count, ignore=[], incl
     logging.info("All jobs processed - closing up pool.")
     pool.join()
 
-    
+
+def lookup_dataserver(redirector, path, timeout=10):
+    """
+    Look up an individual data server from a redirector.
+    If lookup fails, return the original redirector.
+
+    For sites where the redirector does not have the cluster filesystem
+    mounted, dirlist requests will fail. Use this function to select
+    a data server.
+    """
+
+    fs = XRootD.client.FileSystem(redirector)
+
+    handler = XRootD.client.utils.AsyncResponseHandler()
+    status = fs.stat(path, timeout=timeout, callback=handler)
+    status, _, hostlist = handler.wait()
+
+    if status.ok:
+        # Return the last URL in the hostlist (the data server)
+        return(str(list(hostlist)[-1].url))
+    else:
+        return redirector
+
+
 def list_dir(work_queue, results_queue, fs):
     """
     Helper thread for listing directories in parallel
@@ -356,7 +379,9 @@ def start_listing_workers(thread_count, work_queue, results_queue, fs):
         
 def process_dir(base_url, directory, output_dir, ignore=[], include=[], thread_count=2):
     global g_failed_dirs
-    fs = XRootD.client.FileSystem(base_url)
+    base_data_url = lookup_dataserver(base_url, directory)
+    fs = XRootD.client.FileSystem(base_data_url)
+    logging.info("Switching from redirector %s to data server %s" % (base_url, base_data_url))
     logging.info("Starting processing of top-level directory %s", directory)
     worklist = [directory]
     base_len = len(directory)

--- a/bin/cvmfs_sync
+++ b/bin/cvmfs_sync
@@ -101,17 +101,19 @@ def should_ignore_path(entry_name, ignore, include):
              return True
     return False
 
+
 def should_ignore_filename(filename):
     #ignore file names with illegal characters ?, *, >, <, [, ], |, ;, &, (, ), $, \
     #https://xrootd.slac.stanford.edu/doc/dev52/XRdv400.htm#_Toc66820389
     should_ignore = False
     bad_chars = ['?', '*', '>', '<', '[', ']', '|', ';', '&', '(', ')', '$', '\\']
     for i in bad_chars:
-       if i in filename:
-           logging.debug("Ignoring file name %s" % filename)
-           should_ignore = True
-           break
+        if i in filename:
+            logging.debug("Ignoring file name %s" % filename)
+            should_ignore = True
+            break
     return should_ignore
+
 
 def graft_filename(filename):
     parent_dir, fname = os.path.split(filename)
@@ -281,8 +283,8 @@ def process_files(base_url, gridftp_base_url, output_dir, count, ignore=[], incl
         if deadline and (time.time() > deadline):
             logging.error("Passed deadline when scanning directory tree")
             break
-        #if len(futures) >= 50000:
-        if len(futures) >= 200:
+        if len(futures) >= 50000:
+        #if len(futures) >= 200:
             logging.info("Queue of 50k files to checksum has been reached; will attempt remainder next time.")
             break
         if gridftp_base_url:
@@ -313,7 +315,7 @@ def process_files(base_url, gridftp_base_url, output_dir, count, ignore=[], incl
                 logging.warning("Timed out when waiting for file %s; will retry later." % future.filename)
                 #timed_out_futures.append(future)
             except Exception as e:
-                logging.error("Failure when trying to checksum %s (size %d); will regenerate.  Exception: %s" % (future.filename, future.size, str(e)))
+                logging.error("Failure when trying to checksum %s (size %d); will regenerate.  Exception type: %s; %s" % (future.filename, future.size, type(e).__name__, str(e)))
                 if "permission denied" in str(e).lower():
                     print("Skipping permission denied error")
                 else:
@@ -366,7 +368,7 @@ def list_dir(work_queue, results_queue, fs):
             results_queue.put((status, dirlist, cwd, starttime), True)
             work_queue.task_done()
 
-            
+
 def start_listing_workers(thread_count, work_queue, results_queue, fs):
     """
     Helper function for launching the directory spider threads
@@ -376,7 +378,7 @@ def start_listing_workers(thread_count, work_queue, results_queue, fs):
         t.setDaemon(True)
         t.start()
 
-        
+
 def process_dir(base_url, directory, output_dir, ignore=[], include=[], thread_count=2):
     global g_failed_dirs
     base_data_url = lookup_dataserver(base_url, directory)

--- a/bin/ligo-auth-gen
+++ b/bin/ligo-auth-gen
@@ -31,12 +31,13 @@ def main():
         valid = True
     except Exception, error:
         print error
-        
+
     all_dns = []
     for i in range(len(opts.group)):
         print("Querying {} and {}".format(opts.group[i], opts.base[i]))
         query = "(&(isMemberOf=%s)(gridX509subject=*))" % opts.group[i]
         results = ldap_obj.search_s(opts.base[i], ldap.SCOPE_SUBTREE, query, ["gridX509subject"])
+        print("Got {} results".format(len(results)))
         for result in results:
             user_dns = result[1].get('gridX509subject', [])
             all_dns += [i.decode('utf-8').replace("\n", " ") for i in user_dns if i.decode('utf-8').startswith("/")]
@@ -48,7 +49,8 @@ def main():
     if opts.output_file:
         dir, fname = os.path.split(opts.output_file)
         fd, name = tempfile.mkstemp(prefix=fname, dir=dir)
-        os.write(fd, b"x509%\n")
+        #os.write(fd, b"x509%\n")
+        os.write(fd, b"scitoken%\n")
         dns = "\n".join(all_dns)
         os.write(fd, dns.encode() + b"\n")
         os.close(fd)


### PR DESCRIPTION
An xrootd redirector may not have the filesystem mounted, so dirlist calls will fail. Before scanning a server, first try to choose an individual data server.