### PR TITLE
Increase max file size from 26GB to 500

### DIFF
--- a/bin/cvmfs_sync
+++ b/bin/cvmfs_sync
@@ -114,7 +114,7 @@ def should_skip(input_url, output_filename, size):
     # CVMFS checksum format has trouble with very large files.
     # There's additionally suspicious-looking failures around zero-sized
     # files.
-    if (size > 26*(1024**3)) or (size == 0):
+    if (size > 500*(1024**3)) or (size == 0):
         return True
 
     if os.path.exists(output_filename):


### PR DESCRIPTION
@jthiltges could you take a look at this.  We hit an issue where a user was trying to have a 100GB file, and it was constantly (silently) being skipped because of this.