### PR TITLE
Stop checking for change of size or mode in directories

### DIFF
--- a/bin/cvmfs_sync
+++ b/bin/cvmfs_sync
@@ -135,6 +135,12 @@ def should_skip(input_url, output_filename, size, output_mode):
     if os.path.exists(output_filename):
         st = os.stat(output_filename)
 
+        if stat.S_ISDIR(output_mode) and stat.S_ISDIR(st.st_mode):
+            g_skip_count += 1
+            return True
+        # TODO: This probably does not handle the case of directories
+        # turning into files
+
         # Compare size and mode to source
         size_ok = size == st.st_size
         mode_ok = output_mode == stat.S_IMODE(st.st_mode)
@@ -160,7 +166,11 @@ def should_skip(input_url, output_filename, size, output_mode):
         else:
             logging.warning("Size/mode mismatch!  Regenerating file %s (size %d) -> %s (size %d)" % \
                     (input_url, size, output_filename, st.st_size))
-            os.unlink(output_filename)
+            try:
+                os.unlink(output_filename)
+            except as e:
+                logging.error("Unable to unlink: %s" % str(e))
+                return True
     try:
         os.makedirs(os.path.split(output_filename)[0])
     except OSError as oe:


### PR DESCRIPTION
This tries to avoid a problem seen with the following log messages:
```
Apr 27 11:16:41 hcc-cvmfs-repo.unl.edu cvmfs-sync-driver[3779856]: WARNING : Size/mode mismatch!  Regenerating file root://stashredirector.fnal.gov//pnfs/fnal.gov/usr/dune/persistent/stash/MaCh3/inputs/TDR/v3/DUNE_2023_FD_CAFs (size 23) -> /cvmfs/dune.osgstorage.org/pnfs/fnal.gov/usr/dune/persistent/stash/MaCh3/inputs/TDR/v3/DUNE_2023_FD_CAFs (size 12288)
Apr 27 11:16:41 hcc-cvmfs-repo.unl.edu cvmfs-sync-driver[3779856]: DEBUG   : Directory list worker 0 working on directory listing of //pnfs/fnal.gov/usr/dune/persistent/stash/MaCh3/inputs/NDGAr/v1a
Apr 27 11:16:41 hcc-cvmfs-repo.unl.edu cvmfs-sync-driver[3779856]: IsADirectoryError: [Errno 21] Is a directory: '/cvmfs/dune.osgstorage.org/pnfs/fnal.gov/usr/dune/persistent/stash/MaCh3/inputs/TDR/v3/DUNE_2023_FD_CAFs'
```
`DUNE_2023_FD_CAFs` is a directory, as the error message shows.  That shouldn't be being checked for a change in size or mode.  It was preventing the other directory shown (`v1a`) from detecting changes in its input files.